### PR TITLE
fix: the unit should be byte for snasphot_chunk_size

### DIFF
--- a/docs/doc/10-deploy/10-node-config/01-metasrv-config.md
+++ b/docs/doc/10-deploy/10-node-config/01-metasrv-config.md
@@ -87,6 +87,6 @@ The following is a list of the parameters available within the [raft_config] sec
 | heartbeat_interval       | Heartbeat interval in milliseconds. Default: 1000                                                                       |
 | install_snapshot_timeout | Install snapshot timeout in milliseconds. Default: 4000                                                                 |
 | max_applied_log_to_keep  | Maximum number of applied Raft logs to keep. Default: 1000                                                              |
-| snapshot_chunk_size      | The size of chunk for transmitting snapshot. The default is 4MB                                                         |
+| snapshot_chunk_size      | The size in bytes of chunk for transmitting snapshot. The default is 4MB                                                |
 | snapshot_logs_since_last | Number of Raft logs since the last snapshot. Default: 1024                                                              |
 | wait_leader_timeout      | Wait leader timeout in milliseconds. Default: 70000                                                                     |


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### fix: the unit should be byte for snasphot_chunk_size

## Changelog


- Bug Fix




## Related Issues