### PR TITLE
Fix: the meta server version introducing install_snapshot_v1 should be 1.2.212

### DIFF
--- a/docs/doc/10-deploy/09-upgrade/10-compatibility.md
+++ b/docs/doc/10-deploy/09-upgrade/10-compatibility.md
@@ -111,10 +111,10 @@ The following is an illustration of current query-meta compatibility:
 
 | Meta version      | Backward compatible with |
 |:------------------|:-------------------------|
-| [0.9.41, 1.2.214) | [0.9.41, 1.2.214)        |
-| [1.2.214, +∞)     | [0.9.41, +∞)             |
+| [0.9.41, 1.2.212) | [0.9.41, 1.2.212)        |
+| [1.2.212, +∞)     | [0.9.41, +∞)             |
 
-- `1.2.214` is compatible with old versions. Rolling upgrade is supported.
+- `1.2.212` is compatible with old versions. Rolling upgrade is supported.
   In this version, databend-meta raft-server introduced a new API `install_snapshot_v1()`.
   The raft-client will try to use either this new API or the original `install_snapshot()`.
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

##### Fix: the meta server version introducing install_snapshot_v1 should be 1.2.212

## Changelog







## Related Issues