### PR TITLE
fix: meta compatibility: `1.2.53` introduces incompatible snapshot format

### DIFF
--- a/docs/guides/10-deploy/09-upgrade/10-compatibility.md
+++ b/docs/guides/10-deploy/09-upgrade/10-compatibility.md
@@ -114,6 +114,11 @@ The following is an illustration of current query-meta compatibility:
 | [0.9.41, 1.2.212) | [0.9.41, 1.2.212)        |
 | [1.2.212, +∞)     | [0.9.41, +∞)             |
 
+
+- `1.2.53` Incompatible snapshot:
+  Snapshot format changed thus during rolling upgrading,
+  it requires all node data to be up-to-date, ensure there is no need to replicate with snapshot. 
+
 - `1.2.212` is compatible with old versions. Rolling upgrade is supported.
   In this version, databend-meta raft-server introduced a new API `install_snapshot_v1()`.
   The raft-client will try to use either this new API or the original `install_snapshot()`.


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### fix: meta compatibility: `1.2.53` introduces incompatible snapshot format

## Changelog


- Bug Fix




## Related Issues