### PR TITLE
docs: added note to connection string

### DIFF
--- a/docs/developer/10-drivers/00-golang.md
+++ b/docs/developer/10-drivers/00-golang.md
@@ -33,7 +33,8 @@ In this step, you'll create a simple Golang program that communicates with Datab
 <StepContent number="1" title="Copy and paste the following code to the file main.go"> 
 
 :::note
-The value of `hostname` in the code below must align with your HTTP handler settings for Databend query service.
+- The code below connects to a local Databend with a SQL user named 'user1' and password 'abc123' as an example. Feel free to use your own values while maintaining the same format.
+- The value of `hostname` in the code below must align with your HTTP handler settings for Databend query service.
 :::
 
 ```go title='main.go'

--- a/docs/developer/10-drivers/01-python.md
+++ b/docs/developer/10-drivers/01-python.md
@@ -82,6 +82,8 @@ pip install databend-py
 ```python title='main.py'
 from databend_py import Client
 
+# Connecting to a local Databend with a SQL user named 'user1' and password 'abc123' as an example.
+# Feel free to use your own values while maintaining the same format.
 # Setting secure=False means the client will connect to Databend using HTTP instead of HTTPS.
 client = Client('user1:abc123@127.0.0.1', port=8000, secure=False)
 client.execute("CREATE DATABASE IF NOT EXISTS bookstore")
@@ -121,6 +123,8 @@ pip install databend-sqlalchemy
 ```python title='main.py'
 from databend_sqlalchemy import connector
 
+# Connecting to a local Databend with a SQL user named 'user1' and password 'abc123' as an example.
+# Feel free to use your own values while maintaining the same format.
 conn = connector.connect(f"http://user1:abc123@127.0.0.1:8000").cursor()
 conn.execute("CREATE DATABASE IF NOT EXISTS bookstore")
 conn.execute("USE bookstore")
@@ -160,6 +164,8 @@ pip install databend-sqlalchemy
 ```python title='main.py'
 from sqlalchemy import create_engine, text
 
+# Connecting to a local Databend with a SQL user named 'user1' and password 'abc123' as an example.
+# Feel free to use your own values while maintaining the same format.
 # Setting secure=False means the client will connect to Databend using HTTP instead of HTTPS.
 engine = create_engine("databend://user1:abc123@127.0.0.1:8000/default?secure=False")
 

--- a/docs/developer/10-drivers/02-nodejs.md
+++ b/docs/developer/10-drivers/02-nodejs.md
@@ -45,6 +45,8 @@ GRANT ALL on *.* TO user1;
 ```js title='databend.js'
 const { Client } = require('databend-driver');
 
+// Connecting to a local Databend with a SQL user named 'user1' and password 'abc123' as an example.
+// Feel free to use your own values while maintaining the same format.
 const dsn = process.env.DATABEND_DSN
     ? process.env.DATABEND_DSN
     : "databend://user1:abc123@localhost:8000/default?sslmode=disable";

--- a/docs/developer/10-drivers/03-jdbc.md
+++ b/docs/developer/10-drivers/03-jdbc.md
@@ -63,6 +63,8 @@ import java.sql.*;
 import java.util.Properties;
 
 public class demo {
+    // Connecting to a local Databend with a SQL user named 'user1' and password 'abc123' as an example.
+    // Feel free to use your own values while maintaining the same format.
     static final String DB_URL = "jdbc:databend://127.0.0.1:8000";
 
     public static void main(String[] args) throws Exception {

--- a/docs/developer/10-drivers/04-rust.md
+++ b/docs/developer/10-drivers/04-rust.md
@@ -66,6 +66,8 @@ use tokio_stream::StreamExt;
 
 #[tokio::main]
 async fn main() {
+    // Connecting to a local Databend with a SQL user named 'user1' and password 'abc123' as an example.
+    // Feel free to use your own values while maintaining the same format.
     let dsn = "databend://user1:abc123@localhost:8000/default?sslmode=disable";
     let client = Client::new(dsn.to_string());
     let conn = client.get_conn().await.unwrap();


### PR DESCRIPTION
I didnt replace the connection strings with their format like "<your_useranme>:<your_passcode> ..." as they are in the tutorials where users can follow along by just copy & paste (the first step in the tutorials creates the sample user "user1" )

Instead, I added the following notes right above the connection string in the code as a reminder:

_// Connecting to a local Databend with a SQL user named 'user1' and password 'abc123' as an example.
// Feel free to use your own values while maintaining the same format._