### PR TITLE
docs: set role and default role

### DIFF
--- a/docs/sql-reference/10-sql-commands/00-ddl/02-user/02-user-show-users.md
+++ b/docs/sql-reference/10-sql-commands/00-ddl/02-user/02-user-show-users.md
@@ -8,7 +8,7 @@ Lists all the users in the system.
 ## Syntax
 
 ```sql
-SHOW USERS;
+SHOW USERS
 ```
 
 ## Examples

--- a/docs/sql-reference/10-sql-commands/00-ddl/02-user/03-user-alter-user.md
+++ b/docs/sql-reference/10-sql-commands/00-ddl/02-user/03-user-alter-user.md
@@ -6,7 +6,11 @@ import FunctionDescription from '@site/src/components/FunctionDescription';
 
 <FunctionDescription description="Introduced or updated: v1.2.30"/>
 
-Modifies a user account in Databend, allowing changes to the user's password and authentication type, as well as setting or unsetting a [network policy](../12-network-policy/index.md).
+Modifies a user account, including:
+
+- Changing the user's password and authentication type.
+- Setting or unsetting a [network policy](../12-network-policy/index.md).
+- Setting the default role. If it is not explicitly set, Databend will default to using the built-in role `public` as the default role.
 
 ## Syntax
 
@@ -19,6 +23,9 @@ ALTER USER <name> WITH SET NETWORK POLICY='<network_policy>'
 
 -- Unset a network policy
 ALTER USER <name> WITH UNSET NETWORK POLICY
+
+-- Set default role
+ALTER USER <name> WITH DEFAULT_ROLE = '<role_name>'
 ```
 
 *auth_type* can be `double_sha1_password` (default), `sha256_password` or `no_password`.
@@ -73,4 +80,52 @@ ALTER USER user1 WITH SET NETWORK POLICY='test_policy';
 ALTER USER user1 WITH SET NETWORK POLICY='test_policy1';
 
 ALTER USER user1 WITH UNSET NETWORK POLICY;
+```
+
+### Setting Default Role
+
+1. Create a user named "user1" and set the default role as "writer":
+
+```sql title='Connect as user "root":'
+
+root@localhost:8000/default> CREATE USER user1 IDENTIFIED BY 'abc123';
+
+CREATE USER user1 IDENTIFIED BY 'abc123'
+
+0 row written in 0.074 sec. Processed 0 row, 0 B (0 row/s, 0 B/s)
+
+root@localhost:8000/default> GRANT ROLE developer TO user1;
+
+GRANT ROLE developer TO user1
+
+0 row read in 0.018 sec. Processed 0 row, 0 B (0 row/s, 0 B/s)
+
+root@localhost:8000/default> GRANT ROLE writer TO user1;
+
+GRANT ROLE writer TO user1
+
+0 row read in 0.013 sec. Processed 0 row, 0 B (0 row/s, 0 B/s)
+
+root@localhost:8000/default> ALTER USER user1 WITH DEFAULT_ROLE = 'writer';
+
+ALTER user user1 WITH DEFAULT_ROLE = 'writer'
+
+0 row written in 0.019 sec. Processed 0 row, 0 B (0 row/s, 0 B/s)
+```
+
+2. Verify the default role of user "user1" using the [SHOW ROLES](04-user-show-roles.md) command:
+
+```sql title='Connect as user "user1":'
+user1@localhost:8000/default> SHOW ROLES;
+
+SHOW roles
+
+┌───────────────────────────────────────────────────────┐
+│    name   │ inherited_roles │ is_current │ is_default │
+├───────────┼─────────────────┼────────────┼────────────┤
+│ developer │               0 │ false      │ false      │
+│ public    │               0 │ false      │ false      │
+│ writer    │               0 │ true       │ true       │
+└───────────────────────────────────────────────────────┘
+3 rows read in 0.014 sec. Processed 0 rows, 0 B (0 rows/s, 0 B/s)
 ```

--- a/docs/sql-reference/10-sql-commands/00-ddl/02-user/04-user-set-role.md
+++ b/docs/sql-reference/10-sql-commands/00-ddl/02-user/04-user-set-role.md
@@ -1,0 +1,38 @@
+---
+title: SET ROLE
+sidebar_position: 5
+---
+
+Switches the active role for a session, and the currently active role can be viewed using the [SHOW ROLES](04-user-show-roles.md) command, with the `is_current` field indicating the active role.
+
+## Syntax
+
+```sql
+SET ROLE <role_name>
+```
+
+## Examples
+
+```sql
+SHOW ROLES;
+
+┌───────────────────────────────────────────────────────┐
+│    name   │ inherited_roles │ is_current │ is_default │
+├───────────┼─────────────────┼────────────┼────────────┤
+│ developer │               0 │ false      │ false      │
+│ public    │               0 │ false      │ false      │
+│ writer    │               0 │ true       │ true       │
+└───────────────────────────────────────────────────────┘
+
+SET ROLE developer;
+
+SHOW ROLES;
+
+┌───────────────────────────────────────────────────────┐
+│    name   │ inherited_roles │ is_current │ is_default │
+├───────────┼─────────────────┼────────────┼────────────┤
+│ developer │               0 │ true       │ false      │
+│ public    │               0 │ false      │ false      │
+│ writer    │               0 │ false      │ true       │
+└───────────────────────────────────────────────────────┘
+```

--- a/docs/sql-reference/10-sql-commands/00-ddl/02-user/04-user-show-roles.md
+++ b/docs/sql-reference/10-sql-commands/00-ddl/02-user/04-user-show-roles.md
@@ -10,16 +10,28 @@ Lists all the roles assigned to the current user.
 ```sql
 SHOW ROLES
 ```
+
+## Output
+
+The command returns the results in a table with these columns:
+
+| Column          | Description                                                 |
+|-----------------|-------------------------------------------------------------|
+| name            | The role name.                                              |
+| inherited_roles | Number of roles inherited by the current role.              |
+| is_current      | Indicates whether the role is currently active.             |
+| is_default      | Indicates whether the role is the default role of the user. |
+
 ## Examples
 
 ```sql
 SHOW ROLES;
 
-┌───────────────────────────────────────────────────────────┐
-│      name     │ inherited_roles │ is_current │ is_default │
-├───────────────┼─────────────────┼────────────┼────────────┤
-│ account_admin │               0 │ true       │ true       │
-│ manager       │               0 │ false      │ false      │
-│ public        │               0 │ false      │ false      │
-└───────────────────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────────┐
+│    name   │ inherited_roles │ is_current │ is_default │
+├───────────┼─────────────────┼────────────┼────────────┤
+│ developer │               0 │ false      │ false      │
+│ public    │               0 │ false      │ false      │
+│ writer    │               0 │ true       │ true       │
+└───────────────────────────────────────────────────────┘
 ```

--- a/docs/sql-reference/10-sql-commands/00-ddl/02-user/04-user-show-roles.md
+++ b/docs/sql-reference/10-sql-commands/00-ddl/02-user/04-user-show-roles.md
@@ -3,7 +3,7 @@ title: SHOW ROLES
 sidebar_position: 6
 ---
 
-Lists all the roles in the system.
+Lists all the roles assigned to the current user.
 
 ## Syntax
 

--- a/docs/sql-reference/10-sql-commands/00-ddl/02-user/index.md
+++ b/docs/sql-reference/10-sql-commands/00-ddl/02-user/index.md
@@ -9,6 +9,7 @@ This page provides reference information for the user and role related commands 
 - [CREATE USER](01-user-create-user.md)
 - [DROP USER](02-user-drop-user.md)
 - [CREATE ROLE](04-user-create-role.md)
+- [SET ROLE](04-user-set-role.md)
 - [DROP ROLE](05-user-drop-role.md)
 
 ## Permissions Management:


### PR DESCRIPTION
- added `SET ROLE` command.
- added `ALTER USER <name> WITH DEFAULT_ROLE = '<role_name>'` syntax for setting default role.
- refactored `SHOW ROLES` command.