### PR TITLE
chore(ci): fix filter

### DIFF
--- a/.github/workflows/docs-commit.translate.yaml
+++ b/.github/workflows/docs-commit.translate.yaml
@@ -7,6 +7,8 @@ on:
     paths-ignore:
     - '.github**/*'
     - 'docs/cn/**/*'
+    - 'docs/release-notes/**/*'
+    - 'docs/release-stable/**/*'
     - 'api/**/*'
     - 'i18n/**/*'
     - 'src/**/*'
@@ -27,7 +29,7 @@ jobs:
     - name: get changed files name
       id: changed_files
       run: |
-        echo "files=$(git diff --diff-filter=acmr --name-only HEAD^ HEAD | grep '\.md$' | grep -v 'cn' | sed -e 's/^/.\//' | tr '\n' ' ')" >> $GITHUB_OUTPUT
+        echo "files=$(git diff --diff-filter=d --name-only HEAD^ HEAD | grep '\.md$' | grep -v 'cn' | sed -e 's/^/.\//' | tr '\n' ' ')" >> $GITHUB_OUTPUT
 
     - name: Run GPT Translate
       uses: 3ru/gpt-translate@v1.1.5


### PR DESCRIPTION
Uppercase means selected, lowercase means excluded. For now, we only need to exclude deletion to work well. I made a mistake before.

It is best not to trigger CI for release-related logs. We should allow each language to directly reuse the English version.