### PR TITLE
docs: show views updates

### DIFF
--- a/docs/en/sql-reference/10-sql-commands/00-ddl/01-table/show-tables.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/01-table/show-tables.md
@@ -4,24 +4,28 @@ sidebar_position: 15
 ---
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.290"/>
+<FunctionDescription description="Introduced or updated: v1.2.415"/>
 
 Lists the tables in the current or a specified database.
+
+:::note
+Starting from version 1.2.415, the SHOW TABLES command no longer includes views in its results. To display views, use [SHOW VIEWS](../05-view/show-views.md) instead.
+:::
 
 ## Syntax
 
 ```sql
 SHOW [ FULL ] TABLES 
-    [ {FROM | IN} <database_name> ] 
-    [ HISTORY ] 
-    [ LIKE '<pattern>' | WHERE <expr> ]
+     [ {FROM | IN} <database_name> ] 
+     [ HISTORY ] 
+     [ LIKE '<pattern>' | WHERE <expr> ]
 ```
 
 | Parameter | Description                                                                                                                 |
 |-----------|-----------------------------------------------------------------------------------------------------------------------------|
 | FULL      | Lists the results with additional information. See [Examples](#examples) for more details.                                  |
 | FROM / IN | Specifies a database. If omitted, the command returns the results from the current database.                                |
-| HISTORY   | If present, the results will include the dropped tables that are still within their retention period (24 hours by default). |
+| HISTORY   | Displays the timestamps of table deletions within the retention period (24 hours by default). If a table has not been deleted yet, the value for `drop_time` is NULL. |
 | LIKE      | Filters the results by their names using case-sensitive pattern matching.                                                   |
 | WHERE     | Filters the results using an expression in the WHERE clause.                                                                |
 

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/05-view/show-views.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/05-view/show-views.md
@@ -5,52 +5,57 @@ sidebar_position: 4
 
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.383"/>
+<FunctionDescription description="Introduced or updated: v1.2.415"/>
 
 Returns a list of view names within the specified database, or within the current database if no database name is provided.
 
 ## Syntax
 
 ```sql
-SHOW VIEWS 
-    [ { FROM | IN } <database_name> ] 
-    [ LIKE '<pattern>' | WHERE <expr> ]
+SHOW [ FULL ] VIEWS 
+     [ { FROM | IN } <database_name> ] 
+     [ HISTORY ] 
+     [ LIKE '<pattern>' | WHERE <expr> ]
 ```
 
 | Parameter | Description                                                                                  |
 |-----------|----------------------------------------------------------------------------------------------|
+| FULL      | Lists the results with additional information. See [Examples](#examples) for more details.   |
 | FROM / IN | Specifies a database. If omitted, the command returns the results from the current database. |
+| HISTORY   | Displays the timestamps of view deletions within the retention period (24 hours by default). If a view has not been deleted yet, the value for `drop_time` is NULL. |
 | LIKE      | Filters the view names using case-sensitive pattern matching with the `%` wildcard.          |
 | WHERE     | Filters the view names using an expression in the WHERE clause.                              |
 
 ## Examples
 
-The following examples demonstrate how to filter out a view named "employee_info" using the `LIKE` and `WHERE` parameters:
-
 ```sql
--- List views starting with 'employee_' in the current database
-SHOW VIEWS LIKE 'employee_%';
+SHOW VIEWS;
 
-┌──────────────────┐
-│ Views_in_default │
-├──────────────────┤
-│ employee_info    │
-└──────────────────┘
+┌───────────────────────────────────────────────────────────────────┐
+│ Views_in_default │                   view_query                   │
+├──────────────────┼────────────────────────────────────────────────┤
+│ books_view       │ SELECT id, title, genre FROM default.books     │
+│ users_view       │ SELECT username, email, age FROM default.users │
+└───────────────────────────────────────────────────────────────────┘
 
-SHOW VIEWS WHERE name LIKE 'employee_%';
+SHOW FULL VIEWS;
 
-┌──────────────────┐
-│ Views_in_default │
-├──────────────────┤
-│ employee_info    │
-└──────────────────┘
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│    views   │ database │ catalog │       owner      │ engine │         create_time        │                   view_query                   │
+├────────────┼──────────┼─────────┼──────────────────┼────────┼────────────────────────────┼────────────────────────────────────────────────┤
+│ books_view │ default  │ default │ NULL             │ VIEW   │ 2024-04-14 23:29:52.916989 │ SELECT id, title, genre FROM default.books     │
+│ users_view │ default  │ default │ NULL             │ VIEW   │ 2024-04-14 23:31:02.918994 │ SELECT username, email, age FROM default.users │
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 
--- Show the view named 'employee_info' in the current database
-SHOW VIEWS WHERE name = 'employee_info';
+-- Delete the view 'books_view'
+DROP VIEW books_view;
 
-┌──────────────────┐
-│ Views_in_default │
-├──────────────────┤
-│ employee_info    │
-└──────────────────┘
+SHOW VIEWS HISTORY;
+
+┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ Views_in_default │                   view_query                   │          drop_time         │
+├──────────────────┼────────────────────────────────────────────────┼────────────────────────────┤
+│ books_view       │ SELECT id, title, genre FROM default.books     │ 2024-04-15 02:29:56.051081 │
+│ users_view       │ SELECT username, email, age FROM default.users │ NULL                       │
+└────────────────────────────────────────────────────────────────────────────────────────────────┘
 ```


### PR DESCRIPTION
1. added a note: _Starting from version 1.2.415, the SHOW TABLES command no longer includes views in its results. To display views, use SHOW VIEWS instead._
2. Updated syntax & examples for SHOW VIEWS.
