### PR TITLE
docs: fix description for CREATE TABLE ... EXTERNAL_LOCATION

### DIFF
--- a/docs/en/sql-reference/10-sql-commands/00-ddl/01-table/10-ddl-create-table.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/01-table/10-ddl-create-table.md
@@ -106,9 +106,7 @@ CREATE TRANSIENT TABLE ...
 
 ## CREATE TABLE ... EXTERNAL_LOCATION
 
-Creates a table and specifies an S3 bucket for the data storage instead of the FUSE engine.
-
-Databend stores the table data in the location configured in the file `databend-query.toml` by default. This option enables you to store the data (in parquet format) in a table in another bucket instead of the default one.
+Creates a table and stores it in an S3 bucket other than the default storage.
 
 Syntax:
 ```sql


### PR DESCRIPTION
Fixed description for the CREATE TABLE ... EXTERNAL_LOCATION command.