### PR TITLE
docs: show settings note

### DIFF
--- a/docs/en/sql-reference/00-sql-reference/20-system-tables/system-temp-files.md
+++ b/docs/en/sql-reference/00-sql-reference/20-system-tables/system-temp-files.md
@@ -6,7 +6,7 @@ import FunctionDescription from '@site/src/components/FunctionDescription';
 
 <FunctionDescription description="Introduced or updated: v1.2.348"/>
 
-Contains information about temporary files created by Databend, such as spill files. To remove the temporary files, use the [VACUUM TEMPORARY FILES](/sql/sql-commands/administration-cmds/vacuum-temp-filesd) command.
+Contains information about temporary files created by Databend, such as spill files. To remove the temporary files, use the [VACUUM TEMPORARY FILES](/sql/sql-commands/administration-cmds/vacuum-temp-files) command.
 
 ```sql
 SELECT

--- a/docs/en/sql-reference/00-sql-reference/20-system-tables/system-temp-files.md
+++ b/docs/en/sql-reference/00-sql-reference/20-system-tables/system-temp-files.md
@@ -6,7 +6,7 @@ import FunctionDescription from '@site/src/components/FunctionDescription';
 
 <FunctionDescription description="Introduced or updated: v1.2.348"/>
 
-Contains information about temporary files created by Databend, such as spill files. To remove the temporary files, use the [VACUUM TEMPORARY FILES](../../10-sql-commands/50-administration-cmds/vacuum-temp-files.md) command.
+Contains information about temporary files created by Databend, such as spill files. To remove the temporary files, use the [VACUUM TEMPORARY FILES](/sql/sql-commands/administration-cmds/vacuum-temp-filesd) command.
 
 ```sql
 SELECT

--- a/docs/en/sql-reference/00-sql-reference/20-system-tables/system-user-functions.md
+++ b/docs/en/sql-reference/00-sql-reference/20-system-tables/system-user-functions.md
@@ -8,7 +8,7 @@ import FunctionDescription from '@site/src/components/FunctionDescription';
 
 Contains information about user-defined functions and external functions in the system.
 
-See also: [SHOW USER FUNCTIONS](../../10-sql-commands/50-administration-cmds/show-user-functions.md).
+See also: [SHOW USER FUNCTIONS](/sql/sql-commands/administration-cmds/show-user-functions).
 
 ```sql
 SELECT * FROM system.user_functions;

--- a/docs/en/sql-reference/10-sql-commands/50-administration-cmds/03-show-settings.md
+++ b/docs/en/sql-reference/10-sql-commands/50-administration-cmds/03-show-settings.md
@@ -30,6 +30,10 @@ Each Databend setting comes with a level that can be Global, Default, or Session
 
 ## Examples
 
+:::note
+As Databend updates the system settings every now and then, this example may not show the most recent results. To view the latest system settings in Databend, please execute `SHOW SETTINGS;` within your Databend instance.
+:::
+
 ```sql
 SHOW SETTINGS LIMIT 5;
 


### PR DESCRIPTION
- added a note to show settings: 

`As Databend updates the system settings every now and then, this example may not show the most recent results. To view the latest system settings in Databend, please execute SHOW SETTINGS; within your Databend instance.`

- fixed broken links.