### PR TITLE
docs: transient table caution

### DIFF
--- a/docs/en/sql-reference/10-sql-commands/00-ddl/01-table/10-ddl-create-table.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/01-table/10-ddl-create-table.md
@@ -99,6 +99,10 @@ Transient tables are used to hold transitory data that does not require a data p
 
 Transient tables help save your storage expenses because they do not need extra space for historical data compared to non-transient tables. See [example](#create-transient-table-1) for detailed explanations.
 
+:::caution
+Concurrent modifications (including write operations) on transient tables may cause data corruption, making the data unreadable. This defect is being addressed. Until fixed, please avoid concurrent modifications on transient tables.
+:::
+
 Syntax:
 ```sql
 CREATE TRANSIENT TABLE ...


### PR DESCRIPTION
added a caution about transient table:

`Concurrent modifications (including write operations) on transient tables may cause data corruption, making the data unreadable. This defect is being addressed. Until fixed, please avoid concurrent modifications on transient tables.`