### PR TITLE
docs: TRY_TO_TIMESTAMP

### DIFF
--- a/docs/en/sql-reference/10-sql-commands/00-ddl/01-table/10-ddl-create-table.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/01-table/10-ddl-create-table.md
@@ -99,6 +99,10 @@ Transient tables are used to hold transitory data that does not require a data p
 
 Transient tables help save your storage expenses because they do not need extra space for historical data compared to non-transient tables. See [example](#create-transient-table-1) for detailed explanations.
 
+:::caution
+Concurrent modifications (including write operations) on transient tables may cause data corruption, making the data unreadable. This defect is being addressed. Until fixed, please avoid concurrent modifications on transient tables.
+:::
+
 Syntax:
 ```sql
 CREATE TRANSIENT TABLE ...

--- a/docs/en/sql-reference/20-sql-functions/05-datetime-functions/try-to-timestamp.md
+++ b/docs/en/sql-reference/20-sql-functions/05-datetime-functions/try-to-timestamp.md
@@ -1,6 +1,9 @@
 ---
 title: TRY_TO_TIMESTAMP
 ---
+import FunctionDescription from '@site/src/components/FunctionDescription';
+
+<FunctionDescription description="Introduced or updated: v1.2.528"/>
 
 A variant of [TO_TIMESTAMP](to-timestamp.md) in Databend that, while performing the same conversion of an input expression to a timestamp, incorporates error-handling support by returning NULL if the conversion fails instead of raising an error.
 
@@ -13,8 +16,10 @@ See also: [TO_TIMESTAMP](to-timestamp.md)
 TRY_TO_TIMESTAMP(<expr>)
 
 -- Convert a string to a timestamp using the given pattern
-TRY_TO_TIMESTAMP(<expr, expr>)
+TRY_TO_TIMESTAMP(<expr>, <pattern>)
 ```
+
+If given two arguments, the function converts the first string to a timestamp based on the pattern specified in the second string. To specify the pattern, use specifiers. The specifiers allow you to define the desired format for date and time values. For a comprehensive list of supported specifiers, see [Formatting Date and Time](../../00-sql-reference/10-data-types/20-data-type-time-date-types.md#formatting-date-and-time).
 
 ## Aliases
 
@@ -31,6 +36,14 @@ SELECT TRY_TO_TIMESTAMP('2022-01-02 02:00:11'), TRY_TO_DATETIME('2022-01-02 02:0
 │ 2022-01-02 02:00:11                     │ 2022-01-02 02:00:11                    │
 └──────────────────────────────────────────────────────────────────────────────────┘
 
+SELECT TRY_TO_TIMESTAMP('2024-06-12 10:21:39', '%Y-%m-%d %H:%M:%S'), TRY_TO_DATETIME('2024-06-12 10:21:39', '%Y-%m-%d %H:%M:%S');
+
+┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ try_to_timestamp('2024-06-12 10:21:39', '%y-%m-%d %h:%m:%s') │ try_to_datetime('2024-06-12 10:21:39', '%y-%m-%d %h:%m:%s') │
+├──────────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────┤
+│ 2024-06-12 10:21:39                                          │ 2024-06-12 10:21:39                                         │
+└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+
 SELECT TRY_TO_TIMESTAMP('databend'), TRY_TO_DATETIME('databend');
 
 ┌────────────────────────────────────────────────────────────┐
@@ -38,4 +51,12 @@ SELECT TRY_TO_TIMESTAMP('databend'), TRY_TO_DATETIME('databend');
 ├──────────────────────────────┼─────────────────────────────┤
 │ NULL                         │ NULL                        │
 └────────────────────────────────────────────────────────────┘
+
+SELECT TRY_TO_TIMESTAMP('2024-06-12 10:21:39', '%y-%m-%d %H:%M:%S'), TRY_TO_DATETIME('2024-06-12 10:21:39', '%y-%m-%d %H:%M:%S');
+
+┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ try_to_timestamp('2024-06-12 10:21:39', '%y-%m-%d %h:%m:%s') │ try_to_datetime('2024-06-12 10:21:39', '%y-%m-%d %h:%m:%s') │
+├──────────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────┤
+│ NULL                                                         │ NULL                                                        │
+└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ```


### PR DESCRIPTION
- Updated the syntax: `TRY_TO_TIMESTAMP(<expr>, <pattern>)`
- Added more examples. 
- Fixes https://github.com/datafuselabs/databend-docs/issues/841