### PR TITLE
docs: Update Clang Installation Method

### DIFF
--- a/docs/cn/guides/90-community/00-contributor/00-building-from-source.md
+++ b/docs/cn/guides/90-community/00-contributor/00-building-from-source.md
@@ -75,7 +75,7 @@ killall -9 databend-query
 1. 在 osx 中构建：
   - 最好使用官方的 clang 而不是 apple clang：
     ```bash
-    brew install clang
+    brew install llvm
     ```
     并设置编译器环境，例如：
 

--- a/docs/en/guides/90-community/00-contributor/00-building-from-source.md
+++ b/docs/en/guides/90-community/00-contributor/00-building-from-source.md
@@ -75,7 +75,7 @@ killall -9 databend-query
 1. Building in osx:
   - better to use official clang instead of apple clang:
     ```bash
-    brew install clang
+    brew install llvm
     ```
     And set compiler environment, for example:
 


### PR DESCRIPTION
The current brew no longer supports brew install clang. Need to use brew install llvm.