### PR TITLE
docs: MUST_CHANGE_PASSWORD

### DIFF
--- a/docs/en/sql-reference/10-sql-commands/00-ddl/02-user/01-user-create-user.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/02-user/01-user-create-user.md
@@ -26,7 +26,7 @@ CREATE [ OR REPLACE ] USER <name> IDENTIFIED [ WITH <auth_type> ] BY '<password>
 ```
 
 - *auth_type* can be `double_sha1_password` (default), `sha256_password` or `no_password`.
-- When `MUST_CHANGE_PASSWORD` is set to `true`, the new user must change password at first login.
+- When `MUST_CHANGE_PASSWORD` is set to `true`, the new user must change password at first login. Users can change their own password using the [ALTER USER](03-user-alter-user.md) command.
 - When you set a default role for a user using CREATE USER or [ALTER USER](03-user-alter-user.md), Databend does not verify the role's existence or automatically grant the role to the user. You must explicitly grant the role to the user for the role to take effect.
 - When `DISABLED` is set to `true`, the new user is created in a disabled state. Users in this state cannot log in to Databend until they are enabled. To enable or disable a created user, use the [ALTER USER](03-user-alter-user.md) command.
 
@@ -155,4 +155,37 @@ ALTER USER u1 WITH DISABLED = FALSE;
 Welcome to BendSQL 0.16.0-homebrew.
 Connecting to localhost:8000 as user u1.
 Connected to Databend Query v1.2.424-nightly-d3a89f708d(rust-1.77.0-nightly-2024-04-17T22:11:59.304509266Z)
+```
+
+### Example 6: Creating User with MUST_CHANGE_PASSWORD
+
+In this example, we will create a user with the `MUST_CHANGE_PASSWORD` option. Then, we will connect to Databend with BendSQL as the new user and change the password.
+
+1. Create a new user named 'eric' with the `MUST_CHANGE_PASSWORD` option set to `TRUE`.
+
+```sql
+CREATE USER eric IDENTIFIED BY 'abc123' WITH MUST_CHANGE_PASSWORD = TRUE;
+```
+
+2. Launch BendSQL and connect to Databend as the new user. Once connected, you'll see a message indicating that a password change is required. 
+
+```bash
+MacBook-Air:~ eric$ bendsql -ueric -pabc123
+```
+
+3. Change the password with the [ALTER USER](03-user-alter-user.md) command.
+
+```bash
+eric@localhost:8000/default> ALTER USER USER() IDENTIFIED BY 'abc456';
+```
+
+4. Quit BendSQL then reconnect with the new password.
+
+```bash
+MacBook-Air:~ eric$ bendsql -ueric -pabc456
+Welcome to BendSQL 0.19.2-1e338e1(2024-07-17T09:02:28.323121000Z).
+Connecting to localhost:8000 as user eric.
+Connected to Databend Query v1.2.567-nightly-78d41aedc7(rust-1.78.0-nightly-2024-07-14T22:10:13.777450105Z)
+
+eric@localhost:8000/default>
 ```

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/02-user/01-user-create-user.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/02-user/01-user-create-user.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 ---
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.424"/>
+<FunctionDescription description="Introduced or updated: v1.2.566"/>
 
 Creates a SQL user.
 
@@ -18,6 +18,7 @@ See also:
 
 ```sql
 CREATE [ OR REPLACE ] USER <name> IDENTIFIED [ WITH <auth_type> ] BY '<password>' 
+[ WITH MUST_CHANGE_PASSWORD = true | false ]
 [ WITH SET PASSWORD POLICY = '<policy_name>' ] -- Set password policy
 [ WITH SET NETWORK POLICY = '<policy_name>' ] -- Set network policy
 [ WITH DEFAULT_ROLE = '<role_name>' ] -- Set default role
@@ -25,6 +26,7 @@ CREATE [ OR REPLACE ] USER <name> IDENTIFIED [ WITH <auth_type> ] BY '<password>
 ```
 
 - *auth_type* can be `double_sha1_password` (default), `sha256_password` or `no_password`.
+- When `MUST_CHANGE_PASSWORD` is set to `true`, the new user must change password at first login.
 - When you set a default role for a user using CREATE USER or [ALTER USER](03-user-alter-user.md), Databend does not verify the role's existence or automatically grant the role to the user. You must explicitly grant the role to the user for the role to take effect.
 - When `DISABLED` is set to `true`, the new user is created in a disabled state. Users in this state cannot log in to Databend until they are enabled. To enable or disable a created user, use the [ALTER USER](03-user-alter-user.md) command.
 

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/02-user/03-user-alter-user.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/02-user/03-user-alter-user.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 ---
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.424"/>
+<FunctionDescription description="Introduced or updated: v1.2.566"/>
 
 Modifies a user account, including:
 
@@ -17,7 +17,13 @@ Modifies a user account, including:
 
 ```sql
 -- Modify password / authentication type
-ALTER USER <name> IDENTIFIED [ WITH auth_type ] BY '<password>'
+ALTER USER <name> IDENTIFIED [ WITH auth_type ] BY '<new_password>' [ WITH MUST_CHANGE_PASSWORD = true | false ]
+
+-- Require user to modify password at next login
+ALTER USER <name> WITH MUST_CHANGE_PASSWORD = true
+
+-- Modify password for currently logged-in user
+ALTER USER USER() IDENTIFIED BY '<new_password>'
 
 -- Set password policy
 ALTER USER <name> WITH SET PASSWORD POLICY = '<policy_name>'
@@ -39,6 +45,7 @@ ALTER USER <name> WITH DISABLED = true | false
 ```
 
 - *auth_type* can be `double_sha1_password` (default), `sha256_password` or `no_password`.
+- When `MUST_CHANGE_PASSWORD` is set to `true`, the new user must change their password at the next login. Please note that this takes effect only for users who have never changed their password since their account was created. If a user has ever changed their password themselves, then they do not need to change it again.
 - When you set a default role for a user using [CREATE USER](01-user-create-user.md) or ALTER USER, Databend does not verify the role's existence or automatically grant the role to the user. You must explicitly grant the role to the user for the role to take effect.
 - `DISABLED` allows you to enable or disable a user. Disabled users cannot log in to Databend until they are enabled. Click [here](01-user-create-user.md#example-5-creating-user-in-disabled-state) to see an example.
 

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/02-user/03-user-alter-user.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/02-user/03-user-alter-user.md
@@ -45,7 +45,7 @@ ALTER USER <name> WITH DISABLED = true | false
 ```
 
 - *auth_type* can be `double_sha1_password` (default), `sha256_password` or `no_password`.
-- When `MUST_CHANGE_PASSWORD` is set to `true`, the new user must change their password at the next login. Please note that this takes effect only for users who have never changed their password since their account was created. If a user has ever changed their password themselves, then they do not need to change it again.
+- When `MUST_CHANGE_PASSWORD` is set to `true`, the user must change their password at the next login. Please note that this takes effect only for users who have never changed their password since their account was created. If a user has ever changed their password themselves, then they do not need to change it again.
 - When you set a default role for a user using [CREATE USER](01-user-create-user.md) or ALTER USER, Databend does not verify the role's existence or automatically grant the role to the user. You must explicitly grant the role to the user for the role to take effect.
 - `DISABLED` allows you to enable or disable a user. Disabled users cannot log in to Databend until they are enabled. Click [here](01-user-create-user.md#example-5-creating-user-in-disabled-state) to see an example.
 


### PR DESCRIPTION
- added MUST_CHANGE_PASSWORD to CREATE USER & ALTER USER. 
- added `ALTER USER USER() IDENTIFIED BY '<new_password>'`:  This allows users to change their own password.

ps. MUST_CHANGE_PASSWORD does not work well with the latest version of bendsql yet, so i didnt include any examples.
Examples will be added once the fix is applied. 

--
Updated: added an example @b41sh 
