### PR TITLE
docs: to_ timestamp updates

### DIFF
--- a/docs/en/sql-reference/00-sql-reference/10-data-types/20-data-type-time-date-types.md
+++ b/docs/en/sql-reference/00-sql-reference/10-data-types/20-data-type-time-date-types.md
@@ -4,7 +4,7 @@ description: Basic Date and Time data type.
 ---
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.564"/>
+<FunctionDescription description="Introduced or updated: v1.2.575"/>
 
 ## Date and Time Data Types
 
@@ -258,7 +258,7 @@ In Databend, certain date and time functions like [TO_DATE](../../20-sql-functio
 |       |                                  | DATE & TIME SPECIFIERS:                                                                                                                                                             |
 | %c    | Sun Jul 8 00:34:60 2001          | Locale’s date and time (e.g., Thu Mar 3 23:05:25 2005).                                                                                                                             |
 | %+    | 2001-07-08T00:34:60.026490+09:30 | ISO 8601 / RFC 3339 date & time format.                                                                                                                                             |
-| %s    | 994518299                        | UNIX timestamp, the number of seconds since 1970-01-01 00:00 UTC.                                                                                                                   |
+| %s    | 994518299                        | UNIX timestamp, the number of seconds since 1970-01-01 00:00 UTC.Databend recommends converting the Integer string into an Integer first, other than using this specifier. See [Converting Integer to Timestamp](/sql/sql-functions/datetime-functions/to-timestamp#example-2-converting-integer-to-timestamp) for an example.                                                                                                                   |
 |       |                                  | SPECIAL SPECIFIERS:                                                                                                                                                                 |
 | %t    |                                  | Literal tab (\t).                                                                                                                                                                   |
 | %n    |                                  | Literal newline (\n).                                                                                                                                                               |

--- a/docs/en/sql-reference/20-sql-functions/05-datetime-functions/to-timestamp.md
+++ b/docs/en/sql-reference/20-sql-functions/05-datetime-functions/to-timestamp.md
@@ -3,7 +3,7 @@ title: TO_TIMESTAMP
 ---
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.538"/>
+<FunctionDescription description="Introduced or updated: v1.2.575"/>
 
 Converts an expression to a date with time.
 
@@ -135,9 +135,22 @@ SELECT TO_TIMESTAMP(1), TO_TIMESTAMP(-1);
 └───────────────────────────────────────────┘
 ```
 
-:::tip
+You can also convert an Integer string into a timestamp:
 
-Please note that a Timestamp value ranges from 1000-01-01 00:00:00.000000 to 9999-12-31 23:59:59.999999. Databend would return an error if you run the following statement:
+```sql
+SELECT TO_TIMESTAMP(TO_INT64('994518299'));
+
+┌─────────────────────────────────────┐
+│ to_timestamp(to_int64('994518299')) │
+├─────────────────────────────────────┤
+│ 2001-07-07 15:04:59                 │
+└─────────────────────────────────────┘
+```
+
+:::note
+- You can use `SELECT TO_TIMESTAMP('994518299', '%s')` for the conversion as well, but it is not recommended. For such conversions, Databend recommends using the method in the example above for better performance.
+
+- A Timestamp value ranges from 1000-01-01 00:00:00.000000 to 9999-12-31 23:59:59.999999. Databend would return an error if you run the following statement:
 
 ```bash
 root@localhost:8000/default> SELECT TO_TIMESTAMP(9999999999999999999);


### PR DESCRIPTION
Databend recommends `SELECT TO_TIMESTAMP(TO_INT64('994518299'))` other than `SELECT TO_TIMESTAMP('994518299', '%s')`.